### PR TITLE
Add support for building and user as "groups"

### DIFF
--- a/server.go
+++ b/server.go
@@ -104,7 +104,7 @@ func (server *Server) searchHandler(w http.ResponseWriter, r *http.Request) {
 
 func (server *Server) flattenEntities(result *[]volkszaehler.Entity, entities []volkszaehler.Entity, parent string) {
 	for _, entity := range entities {
-		if entity.Type == "group" {
+		if entity.Type == "group" || entity.Type == "building" || entity.Type == "user" {
 			server.flattenEntities(result, entity.Children, entity.Title)
 		} else {
 			if parent != "" {


### PR DESCRIPTION
Gravo already supports the handling of groups but the other two types of groups named building and where missing.